### PR TITLE
Switch to using OpenID Connect for publishing artifacts

### DIFF
--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -30,9 +30,8 @@ jobs:
         with:
           new_version: true
 
-  build-and-publish-wheel-to-pypi:
+  build-distributions:
     runs-on: ubuntu-latest
-    environment: "Publish Release"
     steps:
       - name: Check out code
         uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
@@ -44,9 +43,23 @@ jobs:
       - name: Build wheel
         uses: ./.github/actions/build-dist
 
-        # Using full SHA for security
-        # https://docs.github.com/en/actions/learn-github-actions/security-hardening-for-github-actions#using-third-party-actions
+      - name: Upload distribution artifacts
+        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
+        with:
+          name: distributions
+          path: ./dist
+
+  publish-to-pypi:
+    runs-on: ubuntu-latest
+    environment: "Publish Release"
+    permissions:
+      id-token: write
+    needs: ["build-distributions"]
+    steps:
+      - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
+        with:
+            name: distributions
+            path: ./dist
+
       - name: Publish distribution 📦 to PyPI
         uses: pypa/gh-action-pypi-publish@a56da0b891b3dc519c7ee3284aff1fad93cc8598 # v1.8.6
-        with:
-          password: ${{ secrets.PYPI_API_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,11 +10,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Update project metadata for ownership change.
 
+### Internal
+
+- Use OpenID Connect as a [trusted publisher][trusted-publishers] for uploading releases.
+
 ## [0.13.0] - 2022-10-24
 
 ### Added
 
 - Ability for `Choice` to display a custom message instead of the value being selected. This includes a new type alias (`Options`) which supports both the `Mapping[str, str]` and `List[str]` forms. ([#389](https://github.com/plannigan/columbo/pull/389))
+
 ### Deprecated
 
 - The `OptionList` type for `Choice` in favor of `Options` ([#389](https://github.com/plannigan/columbo/pull/389))
@@ -187,3 +192,5 @@ First public release. No code changes from v0.8.0.
 ## [0.1.0] - 2019-10-15
 
 Initial Release
+
+[trusted-publishers]: https://docs.pypi.org/trusted-publishers/


### PR DESCRIPTION
Split building and publishing into distinct jobs to limit access to id-token write permission.