### PR TITLE
Validate value_if_not_asked to prevent invalid values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Raise `ValueError` when dynamic value returns the wrong type.
+- `BasicQuestion` validates `value_if_not_asked` using the `Validator` if provided.
+- `Choice` validates `value_if_not_asked` for dynamic options that depend on the current `Answers`.
 
 ### Removed
 

--- a/tests/sample_data.py
+++ b/tests/sample_data.py
@@ -1,7 +1,7 @@
 from argparse import Namespace
 from typing import List, Mapping, NoReturn, Optional
 
-from columbo import Answers, ShouldAsk
+from columbo import Answers, ShouldAsk, ValidationFailure
 from columbo._interaction import (
     BasicQuestion,
     Choice,
@@ -25,6 +25,7 @@ SOME_DEFAULT = "x"
 SOME_NON_DEFAULT_OPTION = "y"
 SOME_INVALID_OPTION = "NOT_VALID_OPTION"
 SOME_INVALID_ARG_NAME = "--NOT_VALID_OPTION"
+SOME_FAILURE_MESSAGE = "always fail"
 
 
 def some_dynamic_string(answers: Answers) -> str:
@@ -47,6 +48,10 @@ def some_dynamic_bool(_: Answers) -> bool:
     return SOME_OTHER_BOOL
 
 
+def always_fail_validator(value: str, answers: Answers) -> ValidationFailure:
+    return ValidationFailure(SOME_FAILURE_MESSAGE)
+
+
 SOME_DYNAMIC_STRING_RESULT = "--one--"
 SOME_DYNAMIC_OPTION_RESULT = ["--one--", "--two--"]
 SOME_DYNAMIC_MAPPING_OPTION_RESULT = {"--one--": "~~one~~", "--two--": "~~two~~"}
@@ -55,7 +60,7 @@ SOME_DYNAMIC_DEFAULT_RESULT = "--two--"
 SOME_NAMESPACE = Namespace(**{SOME_NAME: SOME_STRING})
 
 
-class SampleQuestion(Question):
+class SampleQuestion(Question[str]):
     """Question class for testing base class functionality or where subclasses need specific handling"""
 
     def ask(self, answers: Answers, no_user_input: bool = False) -> NoReturn:


### PR DESCRIPTION
Adds validation for each questions type. For `BasicQuestion` and `Choice` this validation has to happen in `get_answers()` since the validator depends on the current `Answers`.

Fixes #374 