### PR TITLE
Remove deprecated check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,10 +83,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.11.0] - 2021-08-04
 
-### Changed
-
-- Removed legacy validator signature and logic
-
 ### Added
 
 - `value_if_not_asked` kwarg for `Question` interactions to set a value if the question is not asked ([#169](https://github.com/plannigan/columbo/pull/169))
@@ -96,6 +92,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 * `dataclasses` was not listed as a dependency for versions of Python < 3.7
+
+### Removed
+
+- Support for `Validator`s that return `Optional[str]`
 
 ## [0.10.0] - 2021-02-18
 

--- a/tests/cli_test.py
+++ b/tests/cli_test.py
@@ -304,8 +304,7 @@ def test_to_answer__basic_question_value_not_valid__exception():
     ]
 
     with pytest.raises(CliException):
-        with pytest.deprecated_call():
-            to_answers(questions, Namespace(**{SOME_NAME: SOME_STRING}))
+        to_answers(questions, Namespace(**{SOME_NAME: SOME_STRING}))
 
 
 def test_to_answer__basic_question_dont_ask__value_not_stored():


### PR DESCRIPTION
#123 removed the functionality, but the test case was not updated to remove the check to see if the deprecation warning was raised. Due to issue fixed in `pytest` 8.0 (pytest-dev/pytest#9036), the warning check would be a no-op because an exception was raised.

This PR removes the check that should no longer exist and updates the changelog to more clearly mark the removal of functionality.