### PR TITLE
Add caching for Python dependencies in GitHub Actions workflow

### DIFF
--- a/.github/actions/Cache Python dependencies/action.yml
+++ b/.github/actions/Cache Python dependencies/action.yml
@@ -1,0 +1,32 @@
+name: Python CI
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out the repository
+        uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.9'
+
+      - name: Cache dependencies
+        uses: actions/cache@v3
+        with:
+          path: ~/.cache/pypoetry  # or change based on the tool you use
+          key: ${{ runner.os }}-python-${{ hashFiles('**/pyproject.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-python-
+
+      - name: Install dependencies
+        run: |
+          pip install hatch
+          hatch env create  # creates the virtual environment and installs dependencies
+
+      - name: Run tests
+        run: hatch run test


### PR DESCRIPTION

- Configure `actions/cache` to cache dependencies based on `pyproject.toml` hash
- Install dependencies directly from `pyproject.toml` using `hatch`
- Streamline setup to avoid creating `requirements.txt` or `requirements-test.txt` files