### PR TITLE
Cache Python Dependencies in CI

### DIFF
--- a/.github/actions/Caching Packages Dependencies/action.yml
+++ b/.github/actions/Caching Packages Dependencies/action.yml
@@ -1,4 +1,4 @@
-name: Caching Packages Dependencies
+name: Python CI
 
 on: [push, pull_request]
 
@@ -18,7 +18,7 @@ jobs:
       - name: Cache dependencies
         uses: actions/cache@v3
         with:
-          path: ~/.cache/pypoetry  # or change based on the tool you use
+          path: ~/.cache/pypoetry
           key: ${{ runner.os }}-python-${{ hashFiles('**/pyproject.toml') }}
           restore-keys: |
             ${{ runner.os }}-python-
@@ -26,7 +26,12 @@ jobs:
       - name: Install dependencies
         run: |
           pip install hatch
-          hatch env create  # creates the virtual environment and installs dependencies
+          hatch env create
 
       - name: Run tests
         run: hatch run test
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v3
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}  

--- a/.github/actions/Caching Packages Dependencies/action.yml
+++ b/.github/actions/Caching Packages Dependencies/action.yml
@@ -1,37 +1,125 @@
 name: Python CI
 
-on: [push, pull_request]
+on:
+  pull_request: {}
+  push:
+    branches: ["main"]
+
+env:
+  PYTHON_VERSION: "3.12"
 
 jobs:
-  build:
+  bandit:
     runs-on: ubuntu-latest
-
     steps:
-      - name: Check out the repository
-        uses: actions/checkout@v3
+      - name: Check out code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Cache Hatch dependencies
+        uses: actions/cache@b7c1be3642e46bf76d47072db3a4a1c330a8db62 # v3.3.2
+        with:
+          path: ~/.cache/hatch
+          key: ${{ runner.os }}-hatch-${{ hashFiles('**/*.toml') }}
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0
         with:
-          python-version: '3.9'
+          python-version: ${{ env.PYTHON_VERSION }}
 
-      - name: Cache dependencies
-        uses: actions/cache@v3
+      - name: Initialize Hatch
+        uses: ./.github/actions/initialize-hatch
+
+      - name: Run bandit
+        run: hatch run bandit-ci
+
+  flake8:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Cache Hatch dependencies
+        uses: actions/cache@b7c1be3642e46bf76d47072db3a4a1c330a8db62 # v3.3.2
         with:
-          path: ~/.cache/pypoetry
-          key: ${{ runner.os }}-python-${{ hashFiles('**/pyproject.toml') }}
-          restore-keys: |
-            ${{ runner.os }}-python-
+          path: ~/.cache/hatch
+          key: ${{ runner.os }}-hatch-${{ hashFiles('**/*.toml') }}
 
-      - name: Install dependencies
-        run: |
-          pip install hatch
-          hatch env create
-
-      - name: Run tests
-        run: hatch run test
-
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
+      - name: Set up Python
+        uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}  
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Initialize Hatch
+        uses: ./.github/actions/initialize-hatch
+
+      - name: Run flake8
+        run: hatch run flake8-check
+
+  isort:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Cache Hatch dependencies
+        uses: actions/cache@b7c1be3642e46bf76d47072db3a4a1c330a8db62 # v3.3.2
+        with:
+          path: ~/.cache/hatch
+          key: ${{ runner.os }}-hatch-${{ hashFiles('**/*.toml') }}
+
+      - name: Set up Python
+        uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Initialize Hatch
+        uses: ./.github/actions/initialize-hatch
+
+      - name: Run isort
+        run: hatch run isort-check
+
+  mypy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Cache Hatch dependencies
+        uses: actions/cache@b7c1be3642e46bf76d47072db3a4a1c330a8db62 # v3.3.2
+        with:
+          path: ~/.cache/hatch
+          key: ${{ runner.os }}-hatch-${{ hashFiles('**/*.toml') }}
+
+      - name: Set up Python
+        uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Initialize Hatch
+        uses: ./.github/actions/initialize-hatch
+
+      - name: Run mypy
+        run: hatch run mypy-check
+
+  renovate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Cache Hatch dependencies
+        uses: actions/cache@b7c1be3642e46bf76d47072db3a4a1c330a8db62 # v3.3.2
+        with:
+          path: ~/.cache/hatch
+          key: ${{ runner.os }}-hatch-${{ hashFiles('**/*.toml') }}
+
+      - name: Set up Python
+        uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Initialize Hatch
+        uses: ./.github/actions/initialize-hatch
+
+      - name: Run renovate
+        run: hatch run renovate-check

--- a/.github/actions/Caching Packages Dependencies/action.yml
+++ b/.github/actions/Caching Packages Dependencies/action.yml
@@ -1,0 +1,32 @@
+name: Caching Packages Dependencies
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out the repository
+        uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.9'
+
+      - name: Cache dependencies
+        uses: actions/cache@v3
+        with:
+          path: ~/.cache/pypoetry  # or change based on the tool you use
+          key: ${{ runner.os }}-python-${{ hashFiles('**/pyproject.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-python-
+
+      - name: Install dependencies
+        run: |
+          pip install hatch
+          hatch env create  # creates the virtual environment and installs dependencies
+
+      - name: Run tests
+        run: hatch run test

--- a/.github/actions/Caching Packages Dependencies/action.yml
+++ b/.github/actions/Caching Packages Dependencies/action.yml
@@ -32,6 +32,11 @@ jobs:
       - name: Run bandit
         run: hatch run bandit-ci
 
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@4fe5e9b96fb9e0c318c1b94e23ae36368e3c6c07 # v3
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+
   flake8:
     runs-on: ubuntu-latest
     steps:
@@ -54,6 +59,11 @@ jobs:
 
       - name: Run flake8
         run: hatch run flake8-check
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@4fe5e9b96fb9e0c318c1b94e23ae36368e3c6c07 # v3
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
 
   isort:
     runs-on: ubuntu-latest
@@ -78,6 +88,11 @@ jobs:
       - name: Run isort
         run: hatch run isort-check
 
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@4fe5e9b96fb9e0c318c1b94e23ae36368e3c6c07 # v3
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+
   mypy:
     runs-on: ubuntu-latest
     steps:
@@ -101,6 +116,11 @@ jobs:
       - name: Run mypy
         run: hatch run mypy-check
 
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@4fe5e9b96fb9e0c318c1b94e23ae36368e3c6c07 # v3
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+
   renovate:
     runs-on: ubuntu-latest
     steps:
@@ -123,3 +143,8 @@ jobs:
 
       - name: Run renovate
         run: hatch run renovate-check
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@4fe5e9b96fb9e0c318c1b94e23ae36368e3c6c07 # v3
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
- Implemented dependency caching to improve CI speed by reducing installation time.
- Used actions/cache to cache dependencies based on pyproject.toml hash.
- Set up hatch to install dependencies directly from pyproject.toml, eliminating the need for requirements files.

Explanation:
In this update, I added caching support to the GitHub Actions workflow to speed up dependency installation. Since the project specifies dependencies in pyproject.toml (and not in requirements.txt), I used actions/cache to cache dependencies based on the hash of pyproject.toml.

Procedure:
First, I configured actions/cache to save dependencies in the cache directory for Python, using the hash of pyproject.toml as the cache key. This means that changes to pyproject.toml will automatically update the cache, keeping dependencies in sync with the file.
Next, I configured a step to install hatch and then used it to install dependencies directly from pyproject.toml. This removed the need to create additional requirements files.

Outcome:
Now, when dependencies are unchanged, GitHub Actions will use the cached versions, reducing CI run time and avoiding redundant installations.

Problems:
I Cant fully verify the workflow since i dont have the CodeCov token and the run fails at that point