### PR TITLE
Migrate to uv and ruff for faster development workflow

### DIFF
--- a/.bandit
+++ b/.bandit
@@ -1,2 +1,0 @@
-[bandit]
-exclude: *venv*,*env*,*scratch*,./test,./docs/examples/

--- a/.flake8
+++ b/.flake8
@@ -1,7 +1,0 @@
-[flake8]
-max-line-length = 88
-max-complexity = 8
-ignore = W503,E501
-builtins = unicode
-tee = True
-extend_exclude = venv,env,.venv,scratch,.mypy_cache

--- a/.github/actions/initialize-hatch/action.yml
+++ b/.github/actions/initialize-hatch/action.yml
@@ -1,5 +1,5 @@
 name: "Initialize Hatch"
-description: "Install hatch & create an environment"
+description: "Install hatch & uv, then create an environment"
 inputs:
   environment-name:
     description: "Which environment to create"
@@ -12,7 +12,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: "Install hatch"
+    - name: "Install hatch and uv"
       run: "pip install -r requirements-bootstrap.txt"
       shell: "bash"
     - name: "Create environment"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,73 +6,38 @@ on:
   pull_request: {}
   push:
       branches: ["main"]
+
+permissions:
+  contents: read
+
 env:
-  PYTHON_VERSION: "3.12"
+  PYTHON_VERSION: "3.14"
 
 jobs:
-  bandit:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check out code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: actions/setup-python@83679a892e2d95755f2dac6acb0bfd1e9ac5d548 # v6.1.0
-        with:
-          python-version: ${{ env.PYTHON_VERSION }}
-      - name: Initialize Hatch
-        uses: ./.github/actions/initialize-hatch
-
-      - name: Run bandit
-        run: hatch run bandit-ci
-
-  black:
+  ruff:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Set up Python
-        uses: actions/setup-python@83679a892e2d95755f2dac6acb0bfd1e9ac5d548 # v6.1.0
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: ${{ env.PYTHON_VERSION }}
       - name: Initialize Hatch
         uses: ./.github/actions/initialize-hatch
 
-      - name: Run black
-        run: hatch run black-check
+      - name: Run ruff linter
+        run: hatch run ruff-check
 
-  flake8:
-    runs-on: ubuntu-latest
-    steps:
-        - name: Check out code
-          uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        - uses: actions/setup-python@83679a892e2d95755f2dac6acb0bfd1e9ac5d548 # v6.1.0
-          with:
-            python-version: ${{ env.PYTHON_VERSION }}
-        - name: Initialize Hatch
-          uses: ./.github/actions/initialize-hatch
-
-        - name: Run flake8
-          run: hatch run flake8-check
-
-  isort:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check out code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: actions/setup-python@83679a892e2d95755f2dac6acb0bfd1e9ac5d548 # v6.1.0
-        with:
-          python-version: ${{ env.PYTHON_VERSION }}
-      - name: Initialize Hatch
-        uses: ./.github/actions/initialize-hatch
-
-      - name: Run isort
-        run: hatch run isort-check
+      - name: Run ruff formatter
+        run: hatch run ruff-format-check
 
   mypy:
     runs-on: ubuntu-latest
     steps:
         - name: Check out code
           uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        - uses: actions/setup-python@83679a892e2d95755f2dac6acb0bfd1e9ac5d548 # v6.1.0
+        - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
           with:
             python-version: ${{ env.PYTHON_VERSION }}
         - name: Initialize Hatch
@@ -90,7 +55,7 @@ jobs:
           node-version: 24.13.0
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: 🧼 lint renovate config # Validates changes to renovate.json config file
-        uses: suzuki-shunsuke/github-action-renovate-config-validator@c22827f47f4f4a5364bdba19e1fe36907ef1318e # v1.1.1
+        uses: suzuki-shunsuke/github-action-renovate-config-validator@ca480cb7ec89a9e1cd8c214ad33bda1617184027 # v2.0.0
         with:
           config_file_path: 'renovate.json'
 
@@ -102,7 +67,7 @@ jobs:
     steps:
         - name: Check out code
           uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        - uses: actions/setup-python@83679a892e2d95755f2dac6acb0bfd1e9ac5d548 # v6.1.0
+        - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
           with:
             python-version: ${{ matrix.python-version }}
         - name: Initialize Hatch
@@ -142,7 +107,7 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: actions/setup-python@83679a892e2d95755f2dac6acb0bfd1e9ac5d548 # v6.1.0
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: ${{ matrix.python-version }}
       - name: Build wheel
@@ -165,6 +130,9 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
       - name: Initialize Hatch
         uses: ./.github/actions/initialize-hatch
 
@@ -178,9 +146,10 @@ jobs:
       - name: Check out code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: actions/setup-python@83679a892e2d95755f2dac6acb0bfd1e9ac5d548 # v6.1.0
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: ${{ env.PYTHON_VERSION }}
+
       - name: Initialize Hatch
         uses: ./.github/actions/initialize-hatch
         with:
@@ -198,13 +167,16 @@ jobs:
   update-dev-docs:
     runs-on: ubuntu-latest
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    permissions:
+      contents: write
     steps:
       - name: Check out code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: actions/setup-python@83679a892e2d95755f2dac6acb0bfd1e9ac5d548 # v6.1.0
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: ${{ env.PYTHON_VERSION }}
+
       - name: Initialize Hatch
         uses: ./.github/actions/initialize-hatch
         with:

--- a/columbo/_cli.py
+++ b/columbo/_cli.py
@@ -3,16 +3,11 @@ Produce a CLI based on a sequence of interactions.
 """
 
 from argparse import ArgumentParser, Namespace
+from collections.abc import Collection, Iterable, Sequence
 from functools import singledispatch
 from typing import (
-    Collection,
-    Dict,
-    Iterable,
     NoReturn,
-    Optional,
-    Sequence,
     TypedDict,
-    Union,
     cast,
 )
 
@@ -30,16 +25,16 @@ from columbo._interaction import (
 )
 from columbo._types import Answers, MutableAnswers
 
-CliResult = Union[str, bool]
-CliResults = Dict[str, CliResult]
+CliResult = str | bool
+CliResults = dict[str, CliResult]
 
 
 def parse_args(
     interactions: Collection[Interaction],
-    args: Optional[Sequence[str]] = None,
+    args: Sequence[str] | None = None,
     exit_on_error: bool = True,
-    answers: Optional[Answers] = None,
-    parser_name: Optional[str] = None,
+    answers: Answers | None = None,
+    parser_name: str | None = None,
 ) -> MutableAnswers:
     """
     Parse command line argument for the given interactions.
@@ -74,7 +69,7 @@ def parse_args(
 
 
 def format_cli_help(
-    interactions: Collection[Interaction], parser_name: Optional[str] = None
+    interactions: Collection[Interaction], parser_name: str | None = None
 ) -> str:
     """
     Produce CLI help text for a given set of interactions.
@@ -89,7 +84,7 @@ def format_cli_help(
 
 
 def create_parser(
-    interactions: Collection[Interaction], parser_name: Optional[str] = None
+    interactions: Collection[Interaction], parser_name: str | None = None
 ) -> ArgumentParser:
     parser = ArgumentParser(prog=parser_name, add_help=False)
     for interaction in interactions:
@@ -123,7 +118,7 @@ def _add_argument_for(question: object, _: ArgumentParser) -> None:
 @_add_argument_for.register(Acknowledge)
 @_add_argument_for.register(Echo)
 def _add_argument_for_noop(
-    question: Union[Acknowledge, Echo], parser: ArgumentParser
+    question: Acknowledge | Echo, parser: ArgumentParser
 ) -> None:
     pass
 
@@ -155,7 +150,7 @@ def _add_argument_for_choice(question: Choice, parser: ArgumentParser) -> None:
 def to_answers(
     interactions: Collection[Interaction],
     result: Namespace,
-    answers: Optional[Answers] = None,
+    answers: Answers | None = None,
 ) -> MutableAnswers:
     cli_values: CliResults = vars(result)
     resultant_answers = {} if answers is None else dict(answers)
@@ -176,7 +171,7 @@ def _update_answers(
 @_update_answers.register(Acknowledge)
 @_update_answers.register(Echo)
 def _update_answers_noop(
-    question: Union[Acknowledge, Echo], cli_values: CliResults, answers: MutableAnswers
+    question: Acknowledge | Echo, cli_values: CliResults, answers: MutableAnswers
 ) -> None:
     pass
 
@@ -184,13 +179,13 @@ def _update_answers_noop(
 @_update_answers.register(BasicQuestion)
 @_update_answers.register(Choice)
 def _update_answers_validate(
-    question: Union[BasicQuestion, Choice],
+    question: BasicQuestion | Choice,
     cli_values: CliResults,
     answers: MutableAnswers,
 ) -> None:
     if not question.should_ask(answers):
         return
-    value = cast(Optional[str], cli_values.get(question.name))
+    value = cast(str | None, cli_values.get(question.name))
     if value is None:
         value = to_value(question.default, answers, str)
     result = question.validate(value, answers)
@@ -221,11 +216,11 @@ class _AddArgumentArgs(TypedDict, total=False):
 def _add_argument(
     parser: ArgumentParser,
     name: str,
-    cli_help: Optional[str],
-    dest: Optional[str] = None,
+    cli_help: str | None,
+    dest: str | None = None,
     action: str = "store",
-    choices: Optional[Iterable[str]] = None,
-    const: Optional[bool] = None,
+    choices: Iterable[str] | None = None,
+    const: bool | None = None,
 ) -> None:
     kwargs: _AddArgumentArgs = {}
     if choices is not None:
@@ -244,7 +239,7 @@ def _add_argument(
 def _add_flag(
     parser: ArgumentParser,
     name: str,
-    cli_help: Optional[str],
+    cli_help: str | None,
     active: bool = True,
 ) -> None:
     # store_const is used for boolean values because store_true/store_false automatically set a default for the

--- a/columbo/_exception.py
+++ b/columbo/_exception.py
@@ -1,6 +1,3 @@
-from typing import Optional
-
-
 class ColumboException(Exception):
     """Base exception for exceptions raised by Columbo"""
 
@@ -14,7 +11,7 @@ class CliException(ColumboException):
 
     @classmethod
     def invalid_value(
-        cls, value: str, argument_name: str, error_message: Optional[str] = None
+        cls, value: str, argument_name: str, error_message: str | None = None
     ) -> "CliException":
         formatted_error_message = f": {error_message}" if error_message else ""
         return cls(

--- a/columbo/_interaction.py
+++ b/columbo/_interaction.py
@@ -1,12 +1,9 @@
 import re
 from abc import ABC, abstractmethod
+from collections.abc import Collection, Mapping
 from enum import Enum
 from typing import (
-    Collection,
     Generic,
-    Mapping,
-    Optional,
-    Type,
     TypeGuard,
     TypeVar,
     Union,
@@ -51,7 +48,7 @@ def _or_default(value: object, default: T) -> T:
     return default if isinstance(value, _Sentinel) else cast(T, value)
 
 
-def _should_ask_or_display(should_ask: Optional[ShouldAsk], answers: Answers) -> bool:
+def _should_ask_or_display(should_ask: ShouldAsk | None, answers: Answers) -> bool:
     if should_ask is None:
         return True
     if callable(should_ask):
@@ -65,7 +62,7 @@ class Displayable(ABC):
     """
 
     def __init__(
-        self, message: StaticOrDynamicValue[str], should_ask: Optional[ShouldAsk] = None
+        self, message: StaticOrDynamicValue[str], should_ask: ShouldAsk | None = None
     ) -> None:
         """
         Initialize an instance.
@@ -106,7 +103,7 @@ class Echo(Displayable):
     """Display a message to the user."""
 
     def __init__(
-        self, message: StaticOrDynamicValue[str], should_ask: Optional[ShouldAsk] = None
+        self, message: StaticOrDynamicValue[str], should_ask: ShouldAsk | None = None
     ) -> None:
         """
         Initialize an instance.
@@ -132,7 +129,7 @@ class Echo(Displayable):
         self,
         *,
         message: Possible[StaticOrDynamicValue[str]] = _NOT_GIVEN,
-        should_ask: Possible[Optional[ShouldAsk]] = _NOT_GIVEN,
+        should_ask: Possible[ShouldAsk | None] = _NOT_GIVEN,
     ) -> "Echo":
         """
         Create a new instance like this one, potentially with different values.
@@ -153,7 +150,7 @@ class Acknowledge(Displayable):
     """Display a message to the user and require the user to press ENTER to continue."""
 
     def __init__(
-        self, message: StaticOrDynamicValue[str], should_ask: Optional[ShouldAsk] = None
+        self, message: StaticOrDynamicValue[str], should_ask: ShouldAsk | None = None
     ) -> None:
         """
         Initialize an instance.
@@ -182,7 +179,7 @@ class Acknowledge(Displayable):
         self,
         *,
         message: Possible[StaticOrDynamicValue[str]] = _NOT_GIVEN,
-        should_ask: Possible[Optional[ShouldAsk]] = _NOT_GIVEN,
+        should_ask: Possible[ShouldAsk | None] = _NOT_GIVEN,
     ) -> "Acknowledge":
         """
         Create a new instance like this one, potentially with different values.
@@ -208,9 +205,9 @@ class Question(ABC, Generic[QuestionValue]):
         self,
         name: str,
         message: StaticOrDynamicValue[str],
-        cli_help: Optional[str] = None,
-        should_ask: Optional[ShouldAsk] = None,
-        value_if_not_asked: Optional[QuestionValue] = None,
+        cli_help: str | None = None,
+        should_ask: ShouldAsk | None = None,
+        value_if_not_asked: QuestionValue | None = None,
     ) -> None:
         """
         Initialize an instance.
@@ -236,18 +233,18 @@ class Question(ABC, Generic[QuestionValue]):
             )
 
         self._should_ask = should_ask
-        self._value_if_not_asked: Optional[QuestionValue] = value_if_not_asked
+        self._value_if_not_asked: QuestionValue | None = value_if_not_asked
 
     @property
     def name(self) -> str:
         return self._name
 
     @property
-    def cli_help(self) -> Optional[str]:
+    def cli_help(self) -> str | None:
         return self._cli_help
 
     @property
-    def value_if_not_asked(self) -> Optional[QuestionValue]:
+    def value_if_not_asked(self) -> QuestionValue | None:
         return self._value_if_not_asked
 
     @abstractmethod
@@ -285,9 +282,9 @@ class Confirm(Question[bool]):
         name: str,
         message: StaticOrDynamicValue[str],
         default: StaticOrDynamicValue[bool] = False,
-        cli_help: Optional[str] = None,
-        should_ask: Optional[ShouldAsk] = None,
-        value_if_not_asked: Optional[bool] = None,
+        cli_help: str | None = None,
+        should_ask: ShouldAsk | None = None,
+        value_if_not_asked: bool | None = None,
     ) -> None:
         """
         Initialize an instance.
@@ -342,9 +339,9 @@ class Confirm(Question[bool]):
         name: Possible[str] = _NOT_GIVEN,
         message: Possible[StaticOrDynamicValue[str]] = _NOT_GIVEN,
         default: Possible[StaticOrDynamicValue[bool]] = _NOT_GIVEN,
-        cli_help: Possible[Optional[str]] = _NOT_GIVEN,
-        should_ask: Possible[Optional[ShouldAsk]] = _NOT_GIVEN,
-        value_if_not_asked: Possible[Optional[bool]] = _NOT_GIVEN,
+        cli_help: Possible[str | None] = _NOT_GIVEN,
+        should_ask: Possible[ShouldAsk | None] = _NOT_GIVEN,
+        value_if_not_asked: Possible[bool | None] = _NOT_GIVEN,
     ) -> "Confirm":
         """
         Create a new instance like this one, potentially with different values.
@@ -384,9 +381,9 @@ class Choice(Question[str]):
         message: StaticOrDynamicValue[str],
         options: StaticOrDynamicValue[Options],
         default: StaticOrDynamicValue[str],
-        cli_help: Optional[str] = None,
-        should_ask: Optional[ShouldAsk] = None,
-        value_if_not_asked: Optional[str] = None,
+        cli_help: str | None = None,
+        should_ask: ShouldAsk | None = None,
+        value_if_not_asked: str | None = None,
     ) -> None:
         """
         Initialize an instance.
@@ -464,9 +461,9 @@ class Choice(Question[str]):
         message: Possible[StaticOrDynamicValue[str]] = _NOT_GIVEN,
         options: Possible[StaticOrDynamicValue[Options]] = _NOT_GIVEN,
         default: Possible[StaticOrDynamicValue[str]] = _NOT_GIVEN,
-        cli_help: Possible[Optional[str]] = _NOT_GIVEN,
-        should_ask: Possible[Optional[ShouldAsk]] = _NOT_GIVEN,
-        value_if_not_asked: Possible[Optional[str]] = _NOT_GIVEN,
+        cli_help: Possible[str | None] = _NOT_GIVEN,
+        should_ask: Possible[ShouldAsk | None] = _NOT_GIVEN,
+        value_if_not_asked: Possible[str | None] = _NOT_GIVEN,
     ) -> "Choice":
         """
         Create a new instance like this one, potentially with different values.
@@ -508,10 +505,10 @@ class BasicQuestion(Question[str]):
         name: str,
         message: StaticOrDynamicValue[str],
         default: StaticOrDynamicValue[str],
-        cli_help: Optional[str] = None,
-        should_ask: Optional[ShouldAsk] = None,
-        validator: Optional[Validator] = None,
-        value_if_not_asked: Optional[str] = None,
+        cli_help: str | None = None,
+        should_ask: ShouldAsk | None = None,
+        validator: Validator | None = None,
+        value_if_not_asked: str | None = None,
     ) -> None:
         """
         Initialize an instance.
@@ -604,10 +601,10 @@ class BasicQuestion(Question[str]):
         name: Possible[str] = _NOT_GIVEN,
         message: Possible[StaticOrDynamicValue[str]] = _NOT_GIVEN,
         default: Possible[StaticOrDynamicValue[str]] = _NOT_GIVEN,
-        cli_help: Possible[Optional[str]] = _NOT_GIVEN,
-        should_ask: Possible[Optional[ShouldAsk]] = _NOT_GIVEN,
-        validator: Possible[Optional[Validator]] = _NOT_GIVEN,
-        value_if_not_asked: Possible[Optional[str]] = _NOT_GIVEN,
+        cli_help: Possible[str | None] = _NOT_GIVEN,
+        should_ask: Possible[ShouldAsk | None] = _NOT_GIVEN,
+        validator: Possible[Validator | None] = _NOT_GIVEN,
+        value_if_not_asked: Possible[str | None] = _NOT_GIVEN,
     ) -> "BasicQuestion":
         """
         Create a new instance like this one, potentially with different values.
@@ -641,7 +638,7 @@ class BasicQuestion(Question[str]):
 
 
 def to_value(
-    value: StaticOrDynamicValue[V], answers: Answers, value_type: Type[V]
+    value: StaticOrDynamicValue[V], answers: Answers, value_type: type[V]
 ) -> V:
     if isinstance(value, value_type):
         return value
@@ -666,7 +663,7 @@ def to_labeled_options(
 
 def get_answers(
     interactions: Collection[Interaction],
-    answers: Optional[Answers] = None,
+    answers: Answers | None = None,
     no_user_input: bool = False,
 ) -> MutableAnswers:
     """
@@ -702,7 +699,7 @@ def get_answers(
 
 
 def _is_question(
-    value: Union[Question[QuestionValue], object],
+    value: Question[QuestionValue] | object,
 ) -> TypeGuard[Question[QuestionValue]]:
     # preserve generic type information
     return isinstance(value, Question)
@@ -728,7 +725,7 @@ def canonical_arg_name(name: str) -> str:
 
 
 def validate_duplicate_question_names(
-    interactions: Collection[Interaction], answers: Optional[Answers] = None
+    interactions: Collection[Interaction], answers: Answers | None = None
 ) -> None:
     """
     Ensure that multiple questions don't use the same name.

--- a/columbo/_types.py
+++ b/columbo/_types.py
@@ -1,7 +1,8 @@
 """Type aliases used by the public API"""
 
+from collections.abc import Callable, Mapping, MutableMapping
 from dataclasses import dataclass
-from typing import Callable, List, Literal, Mapping, MutableMapping, TypeVar, Union
+from typing import Literal, TypeVar, Union
 
 
 @dataclass
@@ -15,13 +16,13 @@ class ValidationFailure:
     valid: Literal[False] = False
 
 
-Answer = Union[bool, str]
+Answer = bool | str
 Answers = Mapping[str, Answer]
 MutableAnswers = MutableMapping[str, Answer]
-OptionList = List[str]
-Options = Union[List[str], Mapping[str, str]]
+OptionList = list[str]
+Options = list[str] | Mapping[str, str]
 V = TypeVar("V")
 StaticOrDynamicValue = Union[V, Callable[[Answers], V]]
 ShouldAsk = Callable[[Answers], bool]
-ValidationResponse = Union[ValidationSuccess, ValidationFailure]
+ValidationResponse = ValidationSuccess | ValidationFailure
 Validator = Callable[[str, Answers], ValidationResponse]

--- a/columbo/_user_io.py
+++ b/columbo/_user_io.py
@@ -2,7 +2,7 @@
 Helpful wrappers for prompt-toolkit functionality.
 """
 
-from typing import Mapping, Optional
+from collections.abc import Mapping
 
 from prompt_toolkit import shortcuts
 from prompt_toolkit.formatted_text import merge_formatted_text
@@ -43,7 +43,7 @@ def ask(
     question: str,
     default: str,
     no_user_input: bool = False,
-    validator: Optional[Validator] = None,
+    validator: Validator | None = None,
 ) -> str:
     if no_user_input:
         return default
@@ -87,7 +87,7 @@ def multiple_choice(
     user_choice = ask(
         "\n".join(prompt_lines),
         validator=Validator.from_callable(
-            lambda text: text == _NO_INPUT or text in choice_map.keys()
+            lambda text: text == _NO_INPUT or text in choice_map
         ),
         default=default_choice,
         no_user_input=no_user_input,

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,11 +1,3 @@
-version: '3.4'
-
-x-mount-app-and-user-git-config: &mount-app-and-user-git-config
-  volumes:
-    - ./:/app
-    - ~/.gitconfig:/home/columbo/.gitconfig # allow script to commit as user
-
-
 services:
 
   # a fully loaded development environment to test new code
@@ -18,7 +10,7 @@ services:
       - ./:/app
 
   # run all the tests and linting locally
-  # - black & isort will format code to address issues
+  # - ruff will format code to address issues
   check:
     <<: *devbox
     command: ["hatch", "run", "check"]
@@ -37,5 +29,5 @@ services:
     command: ["hatch", "run", "docs:serve"]
 
   mike:
-    <<: [*mkdocs, *mount-app-and-user-git-config]
+    <<: *mkdocs
     entrypoint: ["hatch", "run", "docs:mike"]

--- a/docker/devbox.dockerfile
+++ b/docker/devbox.dockerfile
@@ -1,19 +1,24 @@
-FROM python:3.13.0-bookworm@sha256:a680a0edc77501edf235bcc10e81b23269b7320bbf6067b457534cf199007601
+FROM python:3.14-bookworm
 
 ARG _USER="columbo"
 ARG _UID="1000"
 ARG _GID="100"
 ARG _SHELL="/bin/bash"
 
+# Install uv system-wide for hatch to use as installer
+ENV UV_NO_CACHE="true"
+RUN curl -LsSf https://astral.sh/uv/install.sh | sh && \
+    cp /root/.local/bin/uv /usr/local/bin/uv && \
+    cp /root/.local/bin/uvx /usr/local/bin/uvx
 
 RUN useradd -m -s "${_SHELL}" -N -u "${_UID}" "${_USER}"
 
-ENV USER ${_USER}
-ENV UID ${_UID}
-ENV GID ${_GID}
-ENV HOME /home/${_USER}
-ENV PATH "${HOME}/.local/bin/:${PATH}"
-ENV PIP_NO_CACHE_DIR "true"
+ENV USER=${_USER}
+ENV UID=${_UID}
+ENV GID=${_GID}
+ENV HOME=/home/${_USER}
+ENV PATH="${HOME}/.local/bin/:${PATH}"
+ENV PIP_NO_CACHE_DIR="true"
 
 
 RUN mkdir /app && chown ${UID}:${GID} /app

--- a/docs/examples/validators.py
+++ b/docs/examples/validators.py
@@ -1,5 +1,4 @@
 import re
-from typing import List
 
 import columbo
 
@@ -12,7 +11,7 @@ def is_email_address(value: str, _: columbo.Answers) -> columbo.ValidationRespon
     return columbo.ValidationSuccess()
 
 
-interactions: List[columbo.Interaction] = [
+interactions: list[columbo.Interaction] = [
     columbo.BasicQuestion(
         "user_email_address",
         "What email address should be used to contact you?",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,8 +7,8 @@ name = "columbo"
 version = "0.14.0"
 description = "Specify a dynamic set of questions to ask a user and get their answers."
 readme = "README.md"
-license = "MIT"
-requires-python = ">=3.10"
+license = {text = "MIT"}
+requires-python = ">=3.10,<4.0"
 authors = [
     { name = "Patrick Lannigan", email = "p.lannigan@gmail.com" },
 ]
@@ -39,17 +39,16 @@ include = [
 
 # environment management & scripts
 [tool.hatch.envs.default]
+installer = "uv"
 description = "Test and lint the project code"
 dependencies = [
-    "bandit==1.9.3",
-    "black==25.12.0",
-    "flake8==7.3.0",
-    "isort==7.0.0",
+    "coverage==7.13.1",
     "mypy==1.19.1",
     "pytest==9.0.2",
     "pytest-cov==7.0.0",
     "pytest-mock==3.15.1",
-    "pdbpp==0.11.7",
+    "pdbpp==0.12.0.post1",
+    "ruff==0.14.14",
 ]
 [tool.hatch.envs.default.scripts]
 test-no-cov = "pytest --no-cov {args}"
@@ -57,34 +56,28 @@ test = "pytest --cov-report html {args}"
 test-ci = "pytest {args}"
 typing = "mypy"
 _fmt = [
-    "black --quiet .",
-    "isort .",
+    "ruff check --fix .",
+    "ruff format .",
 ]
-black-check = "black --check --diff ."
-isort-check = "isort --check-only ."
-flake8-check = "flake8"
-bandit-ci = "bandit --ini .bandit -r ."
-bandit-check = "bandit-ci --quiet"
+ruff-check = "ruff check columbo tests"
+ruff-format-check = "ruff format --check columbo tests"
 check-strict = [
-    "black-check",
-    "isort-check",
+    "ruff-check",
+    "ruff-format-check",
     "typing",
     "test",
-    "flake8-check",
-    "bandit-check",
 ]
 check = [
     "_fmt",
     "typing",
     "test",
-    "flake8-check",
-    "bandit-check",
 ]
 test-docs-examples = [
     "./docker/validate_docs.sh"
 ]
 
 [tool.hatch.envs.bump]
+installer = "uv"
 description = "Release a new version"
 detached = true
 dependencies = [
@@ -94,6 +87,7 @@ dependencies = [
 it = "hyper-bump-it {args}"
 
 [tool.hatch.envs.docs]
+installer = "uv"
 description = "Generate documentation for the project"
 dependencies = [
     "mike==2.1.3",
@@ -135,7 +129,7 @@ disallow_untyped_defs = true
 
 # testing
 [tool.pytest.ini_options]
-addopts = "--cov=columbo --cov-report xml:/tmp/coverage.xml --cov-report term-missing"
+addopts = "--verbose --cov=columbo --cov-report xml:/tmp/coverage.xml --cov-report term-missing"
 testpaths = ["tests"]
 verbosity_assertions = 2
 
@@ -150,13 +144,44 @@ exclude_lines = [
     "pragma: no cover"
 ]
 
-# code formatting
-[tool.black]
+# linting and formatting with ruff
+[tool.ruff]
 line-length = 88
-target-version = ["py310", "py311", "py312", "py313", "py314"]
+target-version = "py310"
 
-[tool.isort]
-profile = "black"
+[tool.ruff.lint]
+select = [
+    "E",    # pycodestyle errors
+    "W",    # pycodestyle warnings
+    "F",    # pyflakes
+    "I",    # isort
+    "UP",   # pyupgrade
+    "B",    # flake8-bugbear
+    "C4",   # flake8-comprehensions
+    "SIM",  # flake8-simplify
+    "S",    # flake8-bandit (security)
+]
+ignore = [
+    "E501",  # line too long (handled by formatter)
+]
+
+[tool.ruff.lint.per-file-ignores]
+"tests/**/*.py" = [
+    "S101",  # assert is standard in pytest
+]
+"docs/examples/**/*.py" = [
+    "S311",  # random is fine for examples, not used for security
+]
+# Generic type aliases with TypeVars must use Union[] syntax for mypy compatibility
+"columbo/_types.py" = ["UP007"]
+"columbo/_interaction.py" = ["UP007"]
+
+[tool.ruff.lint.isort]
+known-first-party = ["columbo"]
+
+[tool.ruff.format]
+quote-style = "double"
+indent-style = "space"
 
 # version bumping
 [tool.hyper-bump-it.git.actions]
@@ -185,4 +210,3 @@ replace_format_pattern = """## [Unreleased]
 [[tool.hyper-bump-it.files]]
 file_glob = ".github/ISSUE_TEMPLATE/bug_report.md"
 search_format_pattern = "`columbo` Version [e.g. {version}]"
-

--- a/requirements-bootstrap.txt
+++ b/requirements-bootstrap.txt
@@ -1,3 +1,5 @@
 # The project dependencies & environments are managed by hatch.
-# This requirements file can be used to do the initial install of hatch.
-hatch==1.16.2
+# uv is used as the installer for faster package installation.
+# This requirements file can be used to do the initial install.
+hatch==1.16.3
+uv==0.9.27

--- a/tests/sample_data.py
+++ b/tests/sample_data.py
@@ -1,5 +1,6 @@
 from argparse import Namespace
-from typing import List, Mapping, NoReturn, Optional
+from collections.abc import Mapping
+from typing import NoReturn
 
 from columbo import Answers, ShouldAsk, ValidationFailure
 from columbo._interaction import (
@@ -32,7 +33,7 @@ def some_dynamic_string(answers: Answers) -> str:
     return f"--{answers['a']}--"
 
 
-def some_dynamic_options(answers: Answers) -> List[str]:
+def some_dynamic_options(answers: Answers) -> list[str]:
     return [f"--{x}--" for x in answers.values()]
 
 
@@ -70,7 +71,7 @@ class SampleQuestion(Question[str]):
 class SampleDisplayable(Displayable):
     """Displayable for testing base class functionality"""
 
-    def __init__(self, message: str, should_ask: Optional[ShouldAsk] = None) -> None:
+    def __init__(self, message: str, should_ask: ShouldAsk | None = None) -> None:
         super().__init__(message, should_ask)
         self._display_called = False
 


### PR DESCRIPTION
## Summary
- Replace black, isort, flake8, and bandit with ruff for linting/formatting
- Add uv as the package installer for hatch environments for faster dependency installation
- Update Docker configuration to install uv and use Python 3.14
- Modernize type annotations to use `X | Y` syntax (Python 3.10+)
- Update GitHub Actions workflow to use ruff instead of separate linting tools
- Remove `.bandit` and `.flake8` config files (now configured in pyproject.toml)